### PR TITLE
Add missing semicolons in msestrings.pas

### DIFF
--- a/lib/common/kernel/msestrings.pas
+++ b/lib/common/kernel/msestrings.pas
@@ -279,16 +279,16 @@ function comparestrlen(const S1,S2: string): integer;
 function msecomparestrlen(const S1,S2: msestring): integer;
                 //case sensitiv, beruecksichtigt nur s1 laenge
 
-function msecomparestr(const S1, S2: msestring): Integer
+function msecomparestr(const S1, S2: msestring): Integer;
                                                {$ifdef FPC} inline; {$endif}
                 //case sensitive
-function msecomparetext(const S1, S2: msestring): Integer
+function msecomparetext(const S1, S2: msestring): Integer;
                                                {$ifdef FPC} inline; {$endif}
                 //case insensitive
-function msecomparestrnatural(const S1, S2: msestring): Integer
+function msecomparestrnatural(const S1, S2: msestring): Integer;
                                                {$ifdef FPC} inline; {$endif}
                 //case sensitive
-function msecomparetextnatural(const S1, S2: msestring): Integer
+function msecomparetextnatural(const S1, S2: msestring): Integer;
                                                {$ifdef FPC} inline; {$endif}
                 //case insensitive
 function mseCompareTextlen(const S1, S2: msestring): Integer;


### PR DESCRIPTION
This is a very minor modification, for the fun to learn how to do pull requests. (And to get rid of fpdoc's warning.)